### PR TITLE
changing macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.user
 doc
 TAGS
+.idea

--- a/velodyne_driver/src/driver/nodelet.cc
+++ b/velodyne_driver/src/driver/nodelet.cc
@@ -82,5 +82,4 @@ void DriverNodelet::devicePoll()
 // Register this plugin with pluginlib.  Names must match nodelet_velodyne.xml.
 //
 // parameters are: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(velodyne_driver, DriverNodelet,
-                        velodyne_driver::DriverNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(velodyne_driver::DriverNodelet, nodelet::Nodelet);

--- a/velodyne_pointcloud/src/conversions/cloud_nodelet.cc
+++ b/velodyne_pointcloud/src/conversions/cloud_nodelet.cc
@@ -45,5 +45,4 @@ namespace velodyne_pointcloud
 // Register this plugin with pluginlib.  Names must match nodelet_velodyne.xml.
 //
 // parameters: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(velodyne_pointcloud, CloudNodelet,
-                        velodyne_pointcloud::CloudNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(velodyne_pointcloud::CloudNodelet, nodelet::Nodelet);

--- a/velodyne_pointcloud/src/conversions/ringcolors_nodelet.cc
+++ b/velodyne_pointcloud/src/conversions/ringcolors_nodelet.cc
@@ -46,5 +46,4 @@ namespace velodyne_pointcloud
 // Register this plugin with pluginlib.  Names must match nodelet_velodyne.xml.
 //
 // parameters: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(velodyne_pointcloud, RingColorsNodelet,
-                        velodyne_pointcloud::RingColorsNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(velodyne_pointcloud::RingColorsNodelet, nodelet::Nodelet);

--- a/velodyne_pointcloud/src/conversions/transform_nodelet.cc
+++ b/velodyne_pointcloud/src/conversions/transform_nodelet.cc
@@ -45,6 +45,5 @@ namespace velodyne_pointcloud
 // Register this plugin with pluginlib.  Names must match nodelet_velodyne.xml.
 //
 // parameters: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(velodyne_pointcloud, TransformNodelet,
-                        velodyne_pointcloud::TransformNodelet,
+PLUGINLIB_EXPORT_CLASS(velodyne_pointcloud::TransformNodelet,
                         nodelet::Nodelet);


### PR DESCRIPTION
Using `PLUGINLIB_DECLARED_CLASS` has been deprecated. Now, `PLUGINLIB_EXPORT_CLASS` should be used instead.

Therefore, changes in different files have been done.