### PR TITLE
DEV-2245 update to use PLUGINLIB_EXPORT_CLASS

### DIFF
--- a/velodyne_driver/src/driver/nodelet.cc
+++ b/velodyne_driver/src/driver/nodelet.cc
@@ -81,6 +81,5 @@ void DriverNodelet::devicePoll()
 
 // Register this plugin with pluginlib.  Names must match nodelet_velodyne.xml.
 //
-// parameters are: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(velodyne_driver, DriverNodelet,
-                        velodyne_driver::DriverNodelet, nodelet::Nodelet);
+// parameters are: class type, base class type
+PLUGINLIB_EXPORT_CLASS(velodyne_driver::DriverNodelet, nodelet::Nodelet);

--- a/velodyne_pointcloud/src/conversions/cloud_nodelet.cc
+++ b/velodyne_pointcloud/src/conversions/cloud_nodelet.cc
@@ -44,6 +44,5 @@ namespace velodyne_pointcloud
 
 // Register this plugin with pluginlib.  Names must match nodelet_velodyne.xml.
 //
-// parameters: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(velodyne_pointcloud, CloudNodelet,
-                        velodyne_pointcloud::CloudNodelet, nodelet::Nodelet);
+// parameters: class type, base class type
+PLUGINLIB_EXPORT_CLASS(velodyne_pointcloud::CloudNodelet, nodelet::Nodelet);

--- a/velodyne_pointcloud/src/conversions/ringcolors_nodelet.cc
+++ b/velodyne_pointcloud/src/conversions/ringcolors_nodelet.cc
@@ -45,6 +45,5 @@ namespace velodyne_pointcloud
 
 // Register this plugin with pluginlib.  Names must match nodelet_velodyne.xml.
 //
-// parameters: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(velodyne_pointcloud, RingColorsNodelet,
-                        velodyne_pointcloud::RingColorsNodelet, nodelet::Nodelet);
+// parameters: class type, base class type
+PLUGINLIB_EXPORT_CLASS(velodyne_pointcloud::RingColorsNodelet, nodelet::Nodelet);

--- a/velodyne_pointcloud/src/conversions/transform_nodelet.cc
+++ b/velodyne_pointcloud/src/conversions/transform_nodelet.cc
@@ -44,7 +44,5 @@ namespace velodyne_pointcloud
 
 // Register this plugin with pluginlib.  Names must match nodelet_velodyne.xml.
 //
-// parameters: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(velodyne_pointcloud, TransformNodelet,
-                        velodyne_pointcloud::TransformNodelet,
-                        nodelet::Nodelet);
+// parameters: class type, base class type
+PLUGINLIB_EXPORT_CLASS(velodyne_pointcloud::TransformNodelet, nodelet::Nodelet);


### PR DESCRIPTION
cartographer docker image wont build without this update.
Need to use PLUGINLIB_EXPORT_CLASS instead of the deprecated PLUGINLIB_DECLARE_CLASS for ros melodic